### PR TITLE
updated convnext_xxl model origin to get rid of error

### DIFF
--- a/models/AIDE.py
+++ b/models/AIDE.py
@@ -229,7 +229,7 @@ class AIDE_Model(nn.Module):
         self.fc = Mlp(2048 + 256 , 1024, 2)
 
         print("build model with convnext_xxl")
-        self.timm_convnext_xxl, _, _ = timm.create_model(
+        self.timm_convnext_xxl = timm.create_model(
             "convnext_xxlarge", pretrained=convnext_path
         )
 

--- a/models/AIDE.py
+++ b/models/AIDE.py
@@ -233,7 +233,7 @@ class AIDE_Model(nn.Module):
             "convnext_xxlarge", pretrained=convnext_path
         )
 
-        self.timm_convnext_xxl = self.timm_convnext_xxl.visual.trunk
+        # self.timm_convnext_xxl = self.timm_convnext_xxl.visual.trunk
         self.timm_convnext_xxl.head.global_pool = nn.Identity()
         self.timm_convnext_xxl.head.flatten = nn.Identity()
 


### PR DESCRIPTION
Hi, it looks like convnext_xxl is now part of the `timm` package, rather than `open_clip`, so I've modified the code accordingly.